### PR TITLE
Email new Netherlands-based GitHub interactors weekly

### DIFF
--- a/dbt/macros/is_location_in_netherlands.sql
+++ b/dbt/macros/is_location_in_netherlands.sql
@@ -1,0 +1,33 @@
+{% macro is_location_in_netherlands(location_column) %}
+    -- GitHub locations are free text, so match on an explicit list of places seen in
+    -- the data plus a few catch-all patterns. Nulls resolve to false, not null.
+    coalesce(
+        {{ location_column }} in (
+            'Almere',
+            'Amsterdam',
+            'Amsterdam, NL',
+            'Amsterdam, The Netherlands',
+            'Amsterdam / Gliwice',
+            'Breda',
+            'Delft',
+            'Delft, The Netherlands',
+            'Eindhoven',
+            'Eindhoven, The Netherlands',
+            'Groningen',
+            'Netherlands',
+            'Nijmegen',
+            'Oegstgeest',
+            'Rotterdam',
+            'Rotterdam, the Netherlands',
+            'The Hague',
+            'The Netherlands',
+            'Tilburg',
+            'Utrecht'
+        )
+        or lower({{ location_column }}) like '%amsterdam%'
+        or lower({{ location_column }}) like '%netherlands%'
+        or {{ location_column }} like '%, NL%'
+        or {{ location_column }} = 'NL',
+        false
+    )
+{% endmacro %}

--- a/dbt/models/marts/_medium__models.yml
+++ b/dbt/models/marts/_medium__models.yml
@@ -45,6 +45,36 @@ models:
       - dbt_expectations.expect_table_column_count_to_be_between:
           min_value: 1
 
+  - name: fct_dbt_interactors
+    columns:
+      - name: username
+        tests:
+          - not_null
+          - unique
+      # A minority of users have no issue or PR in the latest snapshot, e.g. because the
+      # repo they interacted with is no longer scraped, so the first_interaction_ columns
+      # are only asserted for users that do have one.
+      - name: first_interaction_at
+        tests:
+          - not_null:
+              config:
+                where: "num_issues_created is not null or num_prs_created is not null"
+      - name: first_interaction_type
+        tests:
+          - accepted_values:
+              values: ["issue", "pull_request"]
+          - not_null:
+              config:
+                where: "num_issues_created is not null or num_prs_created is not null"
+      - name: first_interaction_url
+        tests:
+          - not_null:
+              config:
+                where: "num_issues_created is not null or num_prs_created is not null"
+    tests:
+      - dbt_expectations.expect_table_column_count_to_be_between:
+          min_value: 1
+
   - name: fct_medium_blogs_per_day
     tests:
       - dbt_expectations.expect_table_column_count_to_be_between:

--- a/dbt/models/marts/fct_dbt_interactors.sql
+++ b/dbt/models/marts/fct_dbt_interactors.sql
@@ -23,6 +23,47 @@ with
             max(created_at) as last_pr_created_at,
         from {{ ref('stg_github_repo_interactors__pull_requests') }}
         group by 1
+    ),
+    interactions as (
+        select
+            issue_creator as username,
+            'issue' as interaction_type,
+            created_at,
+            title,
+            html_url,
+            repository_url
+        from {{ ref('stg_github_repo_interactors__issues') }}
+
+        union all
+
+        select
+            pull_request_creator as username,
+            'pull_request' as interaction_type,
+            created_at,
+            title,
+            html_url,
+            repository_url
+        from {{ ref('stg_github_repo_interactors__pull_requests') }}
+    ),
+    first_interaction as (
+        -- The staging models hold every issue and PR ever opened on a scraped repo, so
+        -- the earliest row per user is their first ever interaction, not merely the
+        -- first one the pipeline happened to see.
+        select
+            username,
+            created_at as first_interaction_at,
+            concat(
+                string_split(repository_url, '/')[4],
+                '/',
+                string_split(repository_url, '/')[5]
+            ) as first_interaction_repo,
+            title as first_interaction_title,
+            interaction_type as first_interaction_type,
+            html_url as first_interaction_url,
+        from interactions
+        -- html_url breaks ties between an issue and a PR opened at the same second
+        qualify
+            row_number() over (partition by username order by created_at, html_url) = 1
     )
 
 select
@@ -35,37 +76,14 @@ select
     pr.num_prs_created,
     pr.first_pr_created_at,
     pr.last_pr_created_at,
-    if(
-        u.location in (
-            'Almere',
-            'Amsterdam',
-            'Amsterdam, NL',
-            'Amsterdam, The Netherlands',
-            'Amsterdam / Gliwice',
-            'Breda',
-            'Delft',
-            'Delft, The Netherlands',
-            'Eindhoven',
-            'Eindhoven, The Netherlands',
-            'Groningen',
-            'Netherlands',
-            'Nijmegen',
-            'Oegstgeest',
-            'Rotterdam',
-            'Rotterdam, the Netherlands',
-            'The Hague',
-            'The Netherlands',
-            'Tilburg',
-            'Utrecht'
-        )
-        or lower(u.location) like '%amsterdam%'
-        or lower(u.location) like '%netherlands%'
-        or u.location like '%, NL%'
-        or u.location = 'NL',
-        true,
-        false
-    ) as is_user_based_in_netherlands,
+    {{ is_location_in_netherlands('u.location') }} as is_user_based_in_netherlands,
+    fi.first_interaction_at,
+    fi.first_interaction_repo,
+    fi.first_interaction_title,
+    fi.first_interaction_type,
+    fi.first_interaction_url,
     u.user_info_extracted_at
 from {{ ref ('stg_github_repo_interactors__users') }} u
 left join issue_stats i on u.username = i.username
 left join pr_stats pr on u.username = pr.username
+left join first_interaction fi on u.username = fi.username

--- a/src/data_products/email_weekly_new_dutch_interactors.py
+++ b/src/data_products/email_weekly_new_dutch_interactors.py
@@ -1,0 +1,96 @@
+import os
+import smtplib
+import ssl
+from email.message import EmailMessage
+from typing import Mapping, Union
+
+import duckdb
+from tabulate import tabulate
+
+from utils.logger import logger
+
+
+class SendNewDutchInteractorEmail:
+    def __init__(self, lookback_days: int):
+        self.lookback_days = lookback_days
+
+    def get_new_dutch_interactors(self) -> Mapping[str, Union[str, int]]:
+        # first_interaction_at is the user's first ever issue or PR on a scraped repo, so
+        # a recent value means the user is new to us rather than newly re-extracted.
+        df = duckdb.connect(database=":memory:").execute(f"""
+                    SELECT
+                        username,
+                        user_url,
+                        location,
+                        first_interaction_type,
+                        first_interaction_repo,
+                        first_interaction_title,
+                        first_interaction_url,
+                        first_interaction_at
+                    FROM read_parquet("{os.getenv('DATA_DIR')}/marts/fct_dbt_interactors.parquet")
+                    WHERE
+                        is_user_based_in_netherlands
+                        and first_interaction_at >= (GET_CURRENT_TIMESTAMP() - INTERVAL {self.lookback_days} DAY)
+                    ORDER BY first_interaction_at DESC
+        """).arrow()
+
+        data = df.to_pydict()
+        logger.debug(f"{data=}")
+        logger.info(
+            f"SELECTed {len(data['username'])} Netherlands-based users whose first issue or PR was created in the last {self.lookback_days} days."
+        )
+        return dict(data)
+
+    def run(self) -> None:
+        interactors = self.get_new_dutch_interactors()
+
+        # Most weeks there are no new Netherlands-based interactors, so stay silent
+        # rather than sending an email with an empty table.
+        if not interactors["username"]:
+            logger.info("No new Netherlands-based interactors, skipping email.")
+            return
+
+        logger.info("Assembling email...")
+
+        sender_email_address = os.getenv("SENDER_EMAIL_ADDRESS")
+        sender_email_password = os.getenv("SENDER_EMAIL_PASSWORD")
+        recipient_email_address = os.getenv("RECIPIENT_EMAIL_ADDRESS")
+
+        msg = EmailMessage()
+        msg["Subject"] = "New Netherlands-based GitHub interactors"
+        msg["From"] = sender_email_address
+        msg["To"] = recipient_email_address
+
+        formatted_interactors = tabulate(
+            list(map(list, zip(*[v for k, v in interactors.items()]))),
+            interactors.keys(),  # type: ignore
+            tablefmt="unsafehtml",
+        )
+        msg.set_content(
+            f"""
+        <!DOCTYPE html>
+        <html>
+            <body>
+                <div style="background-color:#eee;padding:10px 20px;">
+                    <h2 style="font-family:Georgia, 'Times New Roman', Times, serif;color#454349;">Netherlands-based GitHub users whose first issue or PR was created in the last {self.lookback_days} days</h2>
+                </div>
+                <div style="padding:20px 0px">
+                    {formatted_interactors}
+                </div>
+            </body>
+        </html>
+        """,
+            subtype="html",
+        )
+        logger.debug(formatted_interactors)
+
+        if sender_email_address and sender_email_password and recipient_email_address:
+            logger.info("Sending email...")
+            context = ssl.create_default_context()
+            with smtplib.SMTP("smtp.gmail.com", 587) as smtp:
+                smtp.ehlo()
+                smtp.starttls(context=context)
+                smtp.ehlo()
+                smtp.login(sender_email_address, sender_email_password)
+                smtp.send_message(msg)
+                logger.info("Email sent.")

--- a/src/data_products/email_weekly_new_dutch_interactors.py
+++ b/src/data_products/email_weekly_new_dutch_interactors.py
@@ -61,10 +61,12 @@ class SendNewDutchInteractorEmail:
         msg["From"] = sender_email_address
         msg["To"] = recipient_email_address
 
+        # Titles and locations are free text written by any GitHub user, so escape them
+        # rather than using tabulate's unsafehtml format.
         formatted_interactors = tabulate(
             list(map(list, zip(*[v for k, v in interactors.items()]))),
             interactors.keys(),  # type: ignore
-            tablefmt="unsafehtml",
+            tablefmt="html",
         )
         msg.set_content(
             f"""

--- a/src/data_products/main.py
+++ b/src/data_products/main.py
@@ -5,6 +5,9 @@ import papermill as pm  # type: ignore[import-not-found]
 from src.data_products.email_weekly_medium_blogs import SendMediumBlogsEmail
 from src.data_products.email_weekly_new_dbt_discussions import SendNewDbtDiscussionEmail
 from src.data_products.email_weekly_new_dbt_repos import SendNewDbtRepoEmail
+from src.data_products.email_weekly_new_dutch_interactors import (
+    SendNewDutchInteractorEmail,
+)
 
 
 def main() -> None:
@@ -18,6 +21,7 @@ def main() -> None:
     SendMediumBlogsEmail(lookback_days=lookback_days).run()
     SendNewDbtDiscussionEmail(lookback_days=lookback_days).run()
     SendNewDbtRepoEmail(lookback_days=lookback_days).run()
+    SendNewDutchInteractorEmail(lookback_days=lookback_days).run()
     pm.execute_notebook(
         input_path="./src/data_products/jupyter-lite.ipynb",
         output_path="./src/data_products/jupyter-lite.ipynb",


### PR DESCRIPTION
Adds a fourth email to the Friday weekly run, listing GitHub users based in the Netherlands whose first ever issue or PR on a scraped repo falls in the lookback window. Each row carries the username, their GitHub profile URL, location, and the issue or PR that brought them in (type, repo, title, link, creation time).

"New" is keyed on the user's first ever interaction rather than on when the pipeline first extracted them. That is immune to extraction gaps, and it means adding repos to the scrape list — as just happened with SQLMesh, SQLFluff and sqlfmt — does not flood the email with those repos' long-standing contributors. All scraped repos count towards detection, not just `dbt-labs`, since the SQL tooling repos were added precisely to widen the net.

`fct_dbt_interactors` gains `first_interaction_at`, `_repo`, `_title`, `_type` and `_url`. The grain is unchanged at one row per user, so the columns belong on the existing mart rather than in a new one. The Netherlands location matching moves out of that model into `is_location_in_netherlands`, unchanged in behaviour, now that a second consumer needs it.

`fct_dbt_interactors` previously had no tests; it now asserts `not_null`/`unique` on `username`, `accepted_values` on `first_interaction_type`, and `not_null` on the three first-interaction columns. Those three are scoped with a `where` clause: 67 of 5,689 users have no issue or PR in the latest snapshot at all — their `num_issues_created` and `num_prs_created` were already null before this change — so a blanket `not_null` fails.

No workflow change is needed, since `poetry run data_products` already runs in the Friday 04:00 UTC cron.

The email is skipped entirely when no new interactors are found. That is the common case: there are 99 Netherlands-based users in the mart but only 10 whose first interaction was in the last year, so a typical week has nothing to report.

Verified locally against the committed landing zone: `dbt build --select +fct_dbt_interactors` passes 20/20, the data product runs end to end for both the empty and non-empty windows, and `pre-commit run --all-files` is clean.
