### PR TITLE
Size rate limit waits to the actual reset and raise the job timeout

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -27,7 +27,9 @@ env:
 jobs:
   pipeline:
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    # Ingestion waits out GitHub rate limits rather than failing, so the job needs
+    # headroom beyond a normal ~20 minute run for days when throttling is heavy.
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v4
 

--- a/src/ingestion/github_repo_interactors.py
+++ b/src/ingestion/github_repo_interactors.py
@@ -31,6 +31,10 @@ GITHUB_REPOS = [
     "tconbeer/sqlfmt",
 ]
 
+# Concurrent user lookups. GitHub applies secondary rate limits to bursts of parallel
+# requests, so this trades a little throughput for far less time spent backing off.
+USER_INFO_THREAD_COUNT = 4
+
 
 def get_github_repos(repos: List[str]) -> List[Dict[str, object]]:
     """Fetch metadata for individually named `owner/name` repos.
@@ -504,7 +508,7 @@ def get_github_repo_interactor_info(usernames: List[object]) -> List[Dict[str, o
         f"Fetching {len(usernames)} unique GitHub usernames that are new or have not been extracted recently."
     )
 
-    pool = ThreadPool(8)
+    pool = ThreadPool(USER_INFO_THREAD_COUNT)
     user_info = pool.map(
         lambda username: get_username_info(username),
         usernames,

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -25,9 +25,11 @@ from utils.logger import logger
 # GitHub throttles in two distinct ways. A primary rate limit publishes a reset time
 # that can be polled, whereas a secondary (abuse detection) limit publishes nothing and
 # only clears by backing off.
-RATE_LIMIT_POLL_SECONDS = 60
+RATE_LIMIT_POLL_SECONDS = 60  # Longest single sleep before re-checking the allocation.
+RATE_LIMIT_MIN_SLEEP_SECONDS = 5  # Floor between attempts, so retries cannot spin.
 RATE_LIMIT_MAX_WAIT_SECONDS = 60 * 90  # Primary allocations reset hourly.
 SECONDARY_RATE_LIMIT_BACKOFF_SECONDS = 60
+SECONDARY_RATE_LIMIT_MAX_BACKOFF_SECONDS = 60 * 15  # Guards against a bogus header.
 SECONDARY_RATE_LIMIT_MAX_RETRIES = 5
 # Backstop against a response that always looks retryable, e.g. a malformed query
 # returning no data key while the allocation is healthy.
@@ -165,19 +167,57 @@ def request_github_api(
     raise ValueError(f"Unsupported GitHub API method: {method}")
 
 
+def seconds_until(target: datetime) -> float:
+    """Return the seconds remaining until target, never negative."""
+    now = datetime.now(pytz.utc) if target.tzinfo else datetime.now()
+    return max(0.0, (target - now).total_seconds())
+
+
+def get_retry_after_seconds(response: Any) -> Optional[float]:
+    """Read GitHub's own back-off hint from a throttled response.
+
+    GitHub asks clients to honour Retry-After first, then x-ratelimit-reset once the
+    remaining allocation is zero. Returns None when neither header is usable.
+    """
+    headers = getattr(response, "headers", None) or {}
+
+    retry_after = headers.get("Retry-After") or headers.get("retry-after")
+    if retry_after:
+        try:
+            return max(0.0, float(retry_after))
+        except (TypeError, ValueError):
+            logger.warning(f"Could not parse Retry-After header: {retry_after!r}")
+
+    if str(headers.get("x-ratelimit-remaining", "")).strip() == "0":
+        reset_at = headers.get("x-ratelimit-reset")
+        if reset_at is not None:
+            try:
+                return max(0.0, float(reset_at) - time.time())
+            except (TypeError, ValueError):
+                logger.warning(f"Could not parse x-ratelimit-reset header: {reset_at!r}")
+
+    return None
+
+
 def wait_for_rest_rate_limit_reset() -> None:
-    """Poll until the REST allocation is available again."""
+    """Wait until the REST allocation is available again.
+
+    Sleeps up to the published reset time rather than in fixed polling intervals, so a
+    reset that is seconds away does not cost a full poll interval.
+    """
     deadline = time.monotonic() + RATE_LIMIT_MAX_WAIT_SECONDS
     while time.monotonic() < deadline:
-        # Sleep first so that callers always back off before their next request.
-        time.sleep(RATE_LIMIT_POLL_SECONDS)
         reset_time = get_rest_api_reset_time()
         if reset_time is None:
             logger.info("REST rate limit query was refused, continuing to wait...")
+            sleep_seconds = float(RATE_LIMIT_POLL_SECONDS)
         elif reset_time <= datetime.now():
             return
         else:
             logger.info(f"Waiting until {reset_time} for REST allocation to reset...")
+            sleep_seconds = seconds_until(reset_time)
+
+        time.sleep(min(max(sleep_seconds, RATE_LIMIT_MIN_SLEEP_SECONDS), RATE_LIMIT_POLL_SECONDS))
 
     raise GitHubAPIRateLimitError(
         f"REST allocation still exhausted after {RATE_LIMIT_MAX_WAIT_SECONDS} seconds."
@@ -185,18 +225,20 @@ def wait_for_rest_rate_limit_reset() -> None:
 
 
 def wait_for_graphql_rate_limit_reset() -> None:
-    """Poll until the GraphQL allocation is available again."""
+    """Wait until the GraphQL allocation is available again."""
     deadline = time.monotonic() + RATE_LIMIT_MAX_WAIT_SECONDS
     while time.monotonic() < deadline:
-        # Sleep first so that callers always back off before their next request.
-        time.sleep(RATE_LIMIT_POLL_SECONDS)
         reset_info = get_graphql_api_reset_info()
         if reset_info is None:
             logger.info("GraphQL rate limit query was refused, continuing to wait...")
+            sleep_seconds = float(RATE_LIMIT_POLL_SECONDS)
         elif int(reset_info["remaining"]) > 0:  # type: ignore[arg-type]
             return
         else:
             logger.info(f"Waiting until {reset_info['resetAt']} UTC...")
+            sleep_seconds = seconds_until(reset_info["resetAt"])  # type: ignore[arg-type]
+
+        time.sleep(min(max(sleep_seconds, RATE_LIMIT_MIN_SLEEP_SECONDS), RATE_LIMIT_POLL_SECONDS))
 
     raise GitHubGraphqlRateLimitError(
         f"GraphQL allocation still exhausted after {RATE_LIMIT_MAX_WAIT_SECONDS} seconds."
@@ -234,16 +276,31 @@ def call_github_api(
                     f"Still secondary rate limited after {SECONDARY_RATE_LIMIT_MAX_RETRIES} retries."
                 )
 
-            # Secondary limits publish no reset time, so back off exponentially.
-            backoff_seconds = SECONDARY_RATE_LIMIT_BACKOFF_SECONDS * 2 ** (
-                secondary_rate_limit_retries - 1
+            # Prefer GitHub's own hint; fall back to exponential back-off when the
+            # response carries no usable header.
+            backoff_seconds = get_retry_after_seconds(r)
+            if backoff_seconds is None:
+                backoff_seconds = SECONDARY_RATE_LIMIT_BACKOFF_SECONDS * 2 ** (
+                    secondary_rate_limit_retries - 1
+                )
+            backoff_seconds = min(
+                max(backoff_seconds, RATE_LIMIT_MIN_SLEEP_SECONDS),
+                SECONDARY_RATE_LIMIT_MAX_BACKOFF_SECONDS,
             )
-            logger.info(f"Secondary rate limit hit, retrying in {backoff_seconds} seconds...")
+            logger.info(f"Secondary rate limit hit, retrying in {backoff_seconds:.0f} seconds...")
             time.sleep(backoff_seconds)
-        elif method.lower() == "graphql":
-            wait_for_graphql_rate_limit_reset()
         else:
-            wait_for_rest_rate_limit_reset()
+            wait_started = time.monotonic()
+            if method.lower() == "graphql":
+                wait_for_graphql_rate_limit_reset()
+            else:
+                wait_for_rest_rate_limit_reset()
+
+            # The wait returns immediately when the allocation is already healthy, so
+            # enforce a floor to stop a persistently retryable response spinning.
+            remaining_floor = RATE_LIMIT_MIN_SLEEP_SECONDS - (time.monotonic() - wait_started)
+            if remaining_floor > 0:
+                time.sleep(remaining_floor)
 
     raise GitHubAPIRateLimitError(
         f"GitHub API still returning retryable errors after {MAX_RETRIES} retries."


### PR DESCRIPTION
Follow-up to #464. That fix stopped ingestion crashing with `RecursionError`, and [run 30616186012](https://github.com/pgoslatara/medium_scraper/actions/runs/30616186012) confirmed it: ingestion completed for the first time. But the run was then cancelled at the 45 minute job timeout, because waiting out a rate limit takes longer than failing on one.

Ingestion took 42m41s, of which 26 minutes (08:39:30 to 09:05:43) were spent inside rate limit waits. Normal scheduled runs finish in 18 to 31 minutes end to end. That left `data_products` about a minute before the job was killed, so nothing was committed and the week's data was discarded.

Much of that wait was self-inflicted rather than imposed by GitHub:

- The poll loop slept in fixed 60 second units. The log shows `Waiting until 2026-07-31 09:05:46` printed at 09:05:34, so a reset 12 seconds away still cost a full minute.
- Secondary back-off used a flat `60s * 2^n` and ignored the `Retry-After` header GitHub sends, which is usually much shorter.
- Eight concurrent user lookups tripped the secondary limit within 150ms of each other, provoking the throttling they then had to wait out.

Changes:

- Primary waits sleep until the published reset time, capped at one poll interval, instead of in fixed 60 second steps.
- Secondary back-off honours `Retry-After` first, then `x-ratelimit-reset` when the remaining allocation is zero, falling back to exponential only when neither header is usable. Values are clamped to 15 minutes so a bogus header cannot stall the run.
- A five second floor between attempts replaces the previous sleep-before-check. That check existed to stop a persistently retryable response spinning the retry loop; the floor does the same job without charging 60 seconds when the allocation is already healthy.
- User lookups drop from 8 concurrent threads to 4, via a named `USER_INFO_THREAD_COUNT`. The other GitHub pools were already serial.
- `timeout-minutes` goes from 45 to 90. The waits are tighter now, but a heavily throttled day still needs headroom, and this is a public repo so Actions minutes are free.

Verified by replaying throttled responses through `call_github_api` and asserting the actual sleep durations: `Retry-After: 7` sleeps 7s rather than 60s, `x-ratelimit-reset` 12 seconds out sleeps 12s, a missing header falls back to 60s then 120s, `Retry-After: 999999` clamps to 900s, and a healthy allocation after a transient error now costs 5s where it previously cost 60s. Also re-ran the #464 regression cases: no recursion, and a persistently retryable response still terminates with a typed error instead of spinning. `prek run --all-files` passes, including `mypy --strict`.

Note that 90 minutes is a ceiling, not a target. If throttling stays this heavy the concurrency is the lever to pull next, and `USER_INFO_THREAD_COUNT` can go to 1 to make lookups fully serial.
